### PR TITLE
fix: Update API package.json scripts to use Nx commands

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Ravex API",
   "scripts": {
-    "build": "echo 'Build script placeholder - in Nx, this would be handled by Nx build commands'",
-    "start:dev": "echo 'Start dev script placeholder - in Nx, this would be handled by nx serve api'",
+    "build": "nx build api --prod",
+    "start:dev": "nx serve api",
     "typeorm": "ts-node -r tsconfig-paths/register ../../node_modules/typeorm/cli.js --dataSource ormconfig.ts",
     "migration:generate": "npm run typeorm -- migration:generate src/database/migrations/%npm_config_name%",
     "migration:run": "npm run typeorm -- migration:run",


### PR DESCRIPTION
Corrects the placeholder scripts for `build` and `start:dev` in the `apps/api/package.json` file.

- The `build` script is changed to `nx build api --prod`.
- The `start:dev` script is changed to `nx serve api`.

The TypeORM related scripts remain unchanged as they are specific to that workflow.