### PR TITLE
fix: Prepend npx to nx commands in API package.json scripts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Ravex API",
   "scripts": {
-    "build": "nx build api --prod",
-    "start:dev": "nx serve api",
+    "build": "npx nx build api --prod",
+    "start:dev": "npx nx serve api",
     "typeorm": "ts-node -r tsconfig-paths/register ../../node_modules/typeorm/cli.js --dataSource ormconfig.ts",
     "migration:generate": "npm run typeorm -- migration:generate src/database/migrations/%npm_config_name%",
     "migration:run": "npm run typeorm -- migration:run",


### PR DESCRIPTION
I've updated the `build` and `start:dev` scripts in `apps/api/package.json` to use `npx nx ...` instead of just `nx ...`.

This change ensures that the locally installed Nx CLI is correctly resolved and executed when you run these scripts via `npm run ...`, preventing "nx is not recognized" errors in environments where Nx is not globally installed or otherwise not in the PATH for the `apps/api` directory context.

- The `build` script is changed to `npx nx build api --prod`.
- The `start:dev` script is changed to `npx nx serve api`.

The TypeORM related scripts remain unchanged.