### PR TITLE
Looks good! Here's a commit message for the changes:

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Ravex API",
   "scripts": {
-    "build": "npx nx build api --prod",
-    "start:dev": "npx nx serve api",
+    "build": "cd ../../ravex-hiring-platform && npx nx build api --prod",
+    "start:dev": "cd ../../ravex-hiring-platform && npx nx serve api",
     "typeorm": "ts-node -r tsconfig-paths/register ../../node_modules/typeorm/cli.js --dataSource ormconfig.ts",
     "migration:generate": "npm run typeorm -- migration:generate src/database/migrations/%npm_config_name%",
     "migration:run": "npm run typeorm -- migration:run",


### PR DESCRIPTION
```
fix: Ensure Nx commands in API package.json run from workspace root

Updates the `build` and `start:dev` scripts in `apps/api/package.json`
to change the current directory to the Nx workspace root (`../../ravex-hiring-platform`)
before executing `npx nx` commands.

This is necessary because Nx commands must be run from within an Nx
workspace to correctly find `nx.json` and other configuration.
Running `npm run ...` from `apps/api/` was causing `nx` to execute
outside the workspace context.

- `build` script changed to `cd ../../ravex-hiring-platform && npx nx build api --prod`.
- `start:dev` script changed to `cd ../../ravex-hiring-platform && npx nx serve api`.
```