### PR TITLE
fix: Configure workspaceLayout in Nx to find projects

### DIFF
--- a/ravex-hiring-platform/nx.json
+++ b/ravex-hiring-platform/nx.json
@@ -1,5 +1,9 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "workspaceLayout": {
+    "appsDir": "../../apps",
+    "libsDir": "../../libs"
+  },
   "namedInputs": {
     "default": [
       "{projectRoot}/**/*",


### PR DESCRIPTION
Updates `ravex-hiring-platform/nx.json` to include the `workspaceLayout` property. This configuration directs Nx to the correct locations for applications and libraries, which reside outside the `ravex-hiring-platform` directory itself (in `../../apps` and `../../libs` respectively, relative to `nx.json`).

This change allows Nx commands executed from the `ravex-hiring-platform` directory (as invoked by scripts in `apps/api/package.json`) to correctly discover and operate on projects like 'api'. This should resolve the "Cannot find project" errors.