### PR TITLE
Add afterEach to close app after e2e tests

### DIFF
--- a/hire-backend/test/app.e2e-spec.ts
+++ b/hire-backend/test/app.e2e-spec.ts
@@ -15,6 +15,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')


### PR DESCRIPTION
## Summary
- close INestApplication instance after each e2e test

## Testing
- `npm run test:e2e` *(fails: Cannot find module '../common/middleware/tenant.middleware')*

------
https://chatgpt.com/codex/tasks/task_e_68468bc010308322bd52d6f15eb2a8e8