### PR TITLE
Fix README license info

### DIFF
--- a/hire-backend/README.md
+++ b/hire-backend/README.md
@@ -60,7 +60,7 @@ $ npm run test:cov
 
 ## Support
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+Nest is an open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
 
 ## Stay in touch
 
@@ -70,4 +70,4 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 
 ## License
 
-Nest is [MIT licensed](LICENSE).
+This project is currently unlicensed.


### PR DESCRIPTION
## Summary
- clarify that the backend is currently unlicensed
- remove MIT license mention

## Testing
- `npm test` *(fails: ItemsService create and RolesGuard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68468bbbfd848322a74c1aab022bab74