### PR TITLE
Fix import paths in app module

### DIFF
--- a/hire-backend/src/app.module.ts
+++ b/hire-backend/src/app.module.ts
@@ -4,8 +4,8 @@ import { WinstonModule } from 'nest-winston';
 import * as winston from 'winston';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { TenantMiddleware } from '../common/middleware/tenant.middleware';
-import { ItemsModule } from '../items/items.module';
+import { TenantMiddleware } from './common/middleware/tenant.middleware';
+import { ItemsModule } from './items/items.module';
 
 @Module({
   imports: [


### PR DESCRIPTION
## Summary
- correct relative paths for tenant and items modules in `app.module.ts`

## Testing
- `npm test` *(fails: Cannot find module '../common/decorators/roles.decorator')*

------
https://chatgpt.com/codex/tasks/task_e_68468bb7a88483228db9dab6b916cf65