### PR TITLE
Fix MongoDB URI typo

### DIFF
--- a/hire-backend/src/app.module.ts
+++ b/hire-backend/src/app.module.ts
@@ -9,7 +9,7 @@ import { ItemsModule } from '../items/items.module';
 
 @Module({
   imports: [
-    MongooseModule.forRoot('mongodb://localhost/hirerachy'),
+    MongooseModule.forRoot('mongodb://localhost/hierarchy'),
     ItemsModule,
     WinstonModule.forRoot({
       level: 'info',


### PR DESCRIPTION
## Summary
- correct the MongoDB connection string

## Testing
- `npm test` *(fails: Cannot find module '../common/decorators/roles.decorator')*

------
https://chatgpt.com/codex/tasks/task_e_68468bb173b083228b06ba32e2c588ab